### PR TITLE
fix problem with different rounding of floats between perl & php

### DIFF
--- a/scripts/script-C-cut-postprocessor.pl
+++ b/scripts/script-C-cut-postprocessor.pl
@@ -112,10 +112,10 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 		$diffseconds =~ s/0+$// if ($diffseconds =~ /\.[0-9]+/);
 		$outseconds =~ s/0+$// if ($outseconds =~ /\.[0-9]+/);
 		$props{'Record.Cutin'} = $in;
-		$props{'Record.Cutinseconds'} = $inseconds;
-		$props{'Record.Cutdiffseconds'} = $diffseconds;
+		$props{'Record.Cutinseconds'} = sprintf("%0.4f", $inseconds);
+		$props{'Record.Cutdiffseconds'} = sprintf("%0.4f", $diffseconds);
 		$props{'Record.Cutout'} = $out if (defined($out));
-		$props{'Record.Cutoutseconds'} = $outseconds if (defined($outseconds));
+		$props{'Record.Cutoutseconds'} = sprintf("%0.4f", $outseconds) if (defined($outseconds));
 	}
 
 	$props{'Processing.Duration.Intro'} = $introduration if (defined($introduration));


### PR DESCRIPTION
With very short Clips (Testcase was 32 seconds long), the Calculation of the Length between cutin and cutout can rsult in a cut-length, that is not exactly representable as a float (Testcase: Cutinseconds=1703.76 Cutoutseconds=1736.08 Cutdiffseconds=32.3199999999999)

The Perl-Script calculates a Hash across the properties plus the secret and sends all Properties with the Tracker. During the Serialization or the Deserialization the exact representation of the Float changes in a yet unknown way. When the Tracker now re-calculates the Hash based on the received information, the Hashes mismatch and the Call is rejected.

![screenshot from 2018-03-24 11-10-24](https://user-images.githubusercontent.com/142237/37862824-f8d0c4aa-2f53-11e8-93ca-72653bdc8165.png)

This fix explicitly rounds the Floats before the Calculation and Transmission to 4 Digits, which is good enough for frame exact cutting of 60 fps Material.