### PR TITLE
script-B-mount4cut: correctly normalize room names

### DIFF
--- a/scripts/script-B-mount4cut.pl
+++ b/scripts/script-B-mount4cut.pl
@@ -119,8 +119,8 @@ sub prepareTicket {
 		($r, $error, $cmd) = $fuse->doFuseRepairMount($vid, $replacement);
 	} else {
 		if (defined($room)) {
-			$room =~ s/\ +//g;
 			$room = lc($room);
+			$room =~ s/[^a-z0-9-_]+/_/g;
 		}
 		($r, $error, $cmd) = $fuse->doFuseMount($vid, $room, $paddedstart, $paddedlength);
 	}


### PR DESCRIPTION
This now allows us to have room names containing emoji or slashes, which was impossible beforehand.

When merging this, please also merge branch `kunsi-properly-normalize-names` in `voc/cm` repo.