### PR TITLE
script-B-mount4cut: write back correct number of frames to tracker

### DIFF
--- a/scripts/script-B-mount4cut.pl
+++ b/scripts/script-B-mount4cut.pl
@@ -130,7 +130,7 @@ sub prepareTicket {
 	my %props2 = ();
 	$props2{'Record.Room'} = $room if (defined($room));
 	$props2{'Record.DurationSeconds'} = $paddedlength;
-	$props2{'Record.DurationFrames'} = $paddedlength * 25;
+	$props2{'Record.DurationFrames'} = $paddedlength * $fuse->{'fps'};
 	$props2{'Record.EndPadding'} = $endpadding;
 	$props2{'Record.MountCmd'} = $cmd;
 


### PR DESCRIPTION
This value was wrong when fps != 25