### PR TITLE
 script-F-postprocessing-upload: use rsync instead of scp

### DIFF
--- a/scripts/script-F-postprocessing-upload.pl
+++ b/scripts/script-F-postprocessing-upload.pl
@@ -55,18 +55,15 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 	print " OK\n";
 	my $destfile = $props->{'Publishing.UploadTarget'} . '/' . $props->{'Fahrplan.ID'} . "-" . 
 		$props->{'EncodingProfile.Slug'} . '.' . $props->{'EncodingProfile.Extension'};
-	# support old property as fallback
-	my $opts = $props->{'Publishing.UploadOptions'};
-	$opts = $props->{'Processing.Postprocessing.Options'} unless defined ($opts);
-	$opts = "" unless defined ($opts);
 	print "$srcfile (in) -> $destfile (out) ...";
-	my $cmd = "scp -B -p $opts '$srcfile' '$destfile'";
+	# rsync: verbose, '-e ssh', keep partially transferred files, keep mtimes
+	my $cmd = "rsync --verbose --rsh=ssh --partial --times '$srcfile' '$destfile'";
 	my $out = qx( $cmd 2>&1 );
 	my $return = $?;
 	print " exit=$return\n";
 	
 	if ($return eq '0') {
-		$tracker->setTicketDone($tid, 'Encoding postprocessor: scp completed.');
+		$tracker->setTicketDone($tid, "Encoding postprocessor: rsync completed.");
 		# indicate short sleep to wrapper script
 		exit(100);
 	} else {

--- a/scripts/script-F-postprocessing-upload.pl
+++ b/scripts/script-F-postprocessing-upload.pl
@@ -61,6 +61,7 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 	my $out = qx( $cmd 2>&1 );
 	my $return = $?;
 	print " exit=$return\n";
+	$tracker->addLog($tid, $out)
 	
 	if ($return eq '0') {
 		$tracker->setTicketDone($tid, "Encoding postprocessor: rsync completed.");

--- a/scripts/script-F-postprocessing-upload.pl
+++ b/scripts/script-F-postprocessing-upload.pl
@@ -68,9 +68,6 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 		# indicate short sleep to wrapper script
 		exit(100);
 	} else {
-		my $error = $out;
-		$error =~ s/.*(.{1,80})$/$1/m;
-		$error =~ s/[\r\n]//mg;
-		$tracker->setTicketFailed($tid, "Encoding postprocessor: command '$cmd' failed! Output ends with: '$error'");
+		$tracker->setTicketFailed($tid, "Encoding postprocessor: command '$cmd' failed (exitcode $return)!");
 	}
 }


### PR DESCRIPTION
This allows us to resume transfers in case the upload fails due to a
wonky internet connection.

This also removes the tracker properties `Publishing.UploadOptions` and
`Processing.Postprocessing.Options`. For ssh options, operators are
advised to deploy a ssh config instead.

Also, add log to tracker in any case.