### PR TITLE
Add script F upload

### DIFF
--- a/scripts/script-E-postencoding-auphonic.pl
+++ b/scripts/script-E-postencoding-auphonic.pl
@@ -83,14 +83,14 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 			exit(100);
 		} else {
 			$log = join ("\n", $ex->getErrors());
-			$tracker->setTicketFailed($tid, 'postencoding failed:' . $log);
+			$tracker->setTicketFailed($tid, 'Postencoding failed: ' . $log);
 			exit;
 		}
 	}
 
 	# check config properties for auphonic
 	unless (defined ($props->{'Processing.Auphonic.Token'}) and defined ($props->{'Processing.Auphonic.Preset'})) {
-			$tracker->setTicketFailed($tid, "postencoding with Auphonic failed: Property Processing.Auphonic.Token or Processing.Auphonic.Preset missing!");
+			$tracker->setTicketFailed($tid, "Postencoding with Auphonic failed: Property Processing.Auphonic.Token or Processing.Auphonic.Preset missing!");
 			die;
 	}
 
@@ -101,7 +101,7 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 	my $oldMD5 = $props->{'Processing.Auphonic.SourceFileHash'};
 	my $sourcefile = $paths->getPath('Tmp').'/'.$vid.'-'.$props->{'EncodingProfile.Slug'}.".".$props->{'EncodingProfile.Extension'};
 	if (! -f $sourcefile) {
-		print STDERR "WARNING: no source file found ('$sourcefile'), possibly repeating production uneccessarily\n";
+		print STDERR "WARNING: No source file found ('$sourcefile'), possibly repeating production uneccessarily\n";
 		($oldMD5, $sourcefile) = (undef, undef);
 	}
 

--- a/scripts/script-F-upload.pl
+++ b/scripts/script-F-upload.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl -W
+
+use CRS::Tracker::Client;
+use CRS::Paths;
+use boolean;
+use Sys::Hostname;
+
+my $tracker = CRS::Tracker::Client->new();
+my $state = 'uploading';
+my $ticket;
+if (defined($ENV{'CRS_ROOM'}) && $ENV{'CRS_ROOM'} ne '') {
+        my $filter = {};
+        $filter->{'Fahrplan.Room'} = $ENV{'CRS_ROOM'};
+        $ticket = $tracker->assignNextUnassignedForState('encoding', $state, $filter);
+} else {
+        $ticket = $tracker->assignNextUnassignedForState('encoding', $state);
+}
+
+if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
+	print "currently no tickets for $state\n";
+} else {
+	my $tid = $ticket->{id};
+	print "$state ticket # $tid\n";
+
+	my $props = $tracker->getTicketProperties($tid);
+	if (defined($props->{'Fahrplan.Recording.Optout'}) && $props->{'Fahrplan.Recording.Optout'} eq '1') {
+		print "Ticket is opt-out!!\n\n";
+		$tracker->setTicketFailed($tid, 'Recording has optout-flag!');
+		exit(100);
+	}
+
+	if (defined($props->{'Fahrplan.GUID'}) && $props->{'Fahrplan.GUID'} =~ /^FIXME/i) {
+		print "Ticket has FIXME GUID!\n\n";
+		$tracker->setTicketFailed($tid, 'Recording has invalid Fahrplan.GUID!');
+		exit(100);
+	}
+
+	if (defined($props->{'Publishing.Upload.SkipSlaves'}) && $props->{'EncodingProfile.IsMaster'} ne 'yes') {
+		my $hostname = hostname;
+    if (defined($hostname) && index(',' . $props->{'Publishing.Upload.SkipSlaves'} . ',', ",$hostname,") >= 0) {
+			print "\nskipping file upload because it belongs to a slave ticket and this worker is in the skip list!\n";
+			sleep 1;
+			$tracker->setTicketDone($tid, "Encoding $state: upload skipped due to $hostname is part of worker skip list.");
+			exit(100);
+		}
+	}
+
+	my $paths = CRS::Paths->new($props);
+	my $srcfile = $paths->getPath('Output') . "/" . $props->{'Fahrplan.ID'} . 
+		"-" . $props->{'EncodingProfile.Slug'} . "." . $props->{'EncodingProfile.Extension'};
+	print "checking $srcfile...";
+	if (! -e $srcfile) {
+		$tracker->setTicketFailed($tid, 'Encoding postprocessor: srcfile '.$srcfile.' not found!');
+		die "file $srcfile not found\n";
+	}
+	print " OK\n";
+	my $destfile = $props->{'Publishing.UploadTarget'} . '/' . $props->{'Fahrplan.ID'} . "-" . 
+		$props->{'EncodingProfile.Slug'} . '.' . $props->{'EncodingProfile.Extension'};
+	print "$srcfile (in) -> $destfile (out) ...";
+	# rsync: verbose, '-e ssh', keep partially transferred files, keep mtimes
+	my $cmd = "rsync --verbose --rsh=ssh --partial --times '$srcfile' '$destfile'";
+	my $out = qx( $cmd 2>&1 );
+	my $return = $?;
+	print " exit=$return\n";
+	$tracker->addLog($tid, $out);
+	
+	if ($return eq '0') {
+		$tracker->setTicketDone($tid, "Encoding $state: rsync completed.");
+		# indicate short sleep to wrapper script
+		exit(100);
+	} else {
+		$tracker->setTicketFailed($tid, "Encoding $state: command '$cmd' failed (exitcode $return)!");
+	}
+}

--- a/scripts/script-F-upload.pl
+++ b/scripts/script-F-upload.pl
@@ -6,7 +6,7 @@ use boolean;
 use Sys::Hostname;
 
 my $tracker = CRS::Tracker::Client->new();
-my $state = 'uploading';
+my $state = $ENV{CRS_STATE} // 'uploading';
 my $ticket;
 if (defined($ENV{'CRS_ROOM'}) && $ENV{'CRS_ROOM'} ne '') {
         my $filter = {};
@@ -38,7 +38,7 @@ if (!defined($ticket) || ref($ticket) eq 'boolean' || $ticket->{id} <= 0) {
 	if (defined($props->{'Publishing.Upload.SkipSlaves'}) && $props->{'EncodingProfile.IsMaster'} ne 'yes') {
 		my $hostname = hostname;
     if (defined($hostname) && index(',' . $props->{'Publishing.Upload.SkipSlaves'} . ',', ",$hostname,") >= 0) {
-			print "\nskipping file upload because it belongs to a slave ticket and this worker is in the skip list!\n";
+			print "\nskipping file upload because it belongs to a sub ticket and this worker is in the skip list!\n";
 			sleep 1;
 			$tracker->setTicketDone($tid, "Encoding $state: upload skipped due to $hostname is part of worker skip list.");
 			exit(100);


### PR DESCRIPTION
Add a new version of script F which allows us to move the upload step between local encoding and releasing from `postprocessing` to the new `uploading` state.

Therefore the `postprocessing` state is free to be used by the new thumbnail generator (or similar steps) which can then be handled independently from the `publishing` step
