### PR TITLE
feat: Implement check-scripts feature for crs-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-CRS Worker scripts
+# CRS Worker scripts
 
 This repository contains a set of worker scripts that communicate with the 
 https://github.com/crs-tools/tracker , which are used in production.
 
 For other people this can serve as a starting point for developing or forking their own custom scripts.
+
+## Script checks
+
+Before executing the script, `bin/crs_run` will execute checks found in the folder that is specified by `CHECK_DIR`. If the exit code is not equal to `0`, `crs_run` will exit with the exit code from the check. If the check exits with `0`, it will consider it successful and proceed with running the script.

--- a/bin/crs_run
+++ b/bin/crs_run
@@ -16,6 +16,8 @@ shift # dont give scriptname as param to script
 SLEEP_TIME=${SLEEP_TIME:-30}
 export HTTPS_CA_DIR=${HTTPS_CA_DIR:-/etc/ssl/certs}
 
+CHECK_DIR=${CHECK_DIR:-/usr/local/lib/crs-scripts/check-scripts.d}
+
 # short sleep time after work has done
 SLEEP_TIME_SHORT=2
 # long sleep time if no project assigned
@@ -62,6 +64,22 @@ echo "-------------------------------------------"
 ##### BEGIN WHILE LOOP #####
 while true
 do
+    # Run checks
+    if [ -d "$CHECK_DIR" ]; then
+        for file in $CHECK_DIR/*.sh; do
+            if [ -x "${file}" ]; then
+                "${file}"
+                exit_code=$?
+
+                if [[ $exit_code != 0 ]]; then
+                    check_name=$(basename "$file")
+                    echo "Check $check_name failed with code: $exit_code"
+                    exit 0
+                fi
+            fi
+        done
+    fi
+
     echo "------- executing ${SCRIPT} - talking to tracker instance ${CRS_TRACKER} -------"
     "${SCRIPT}" $@
     EC=$?

--- a/bin/crs_run
+++ b/bin/crs_run
@@ -74,7 +74,7 @@ do
                 if [[ $exit_code != 0 ]]; then
                     check_name=$(basename "$file")
                     echo "Check $check_name failed with code: $exit_code"
-                    exit 0
+                    exit $exit_code
                 fi
             fi
         done


### PR DESCRIPTION
The idea is that one can put a script in there to for example check if a network filesystem is mounted and exit the while-loop if not.

See https://forgejo.c3voc.de/voc/cm/src/commit/490d9020fec752c2f8dbe489d7cb9bdbdd720a18/bundlewrap/bundles/crs-worker/files/cifs-check.sh